### PR TITLE
Allow user to write action specific policy for batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ const finalCreateStore = batchedSubscribe(batchDebounce)(createStore);
 const store = finalCreateStore(reducer, intialState);
 ```
 
+### Debounced subscribe handlers for specific action:
+
+```js
+import { createStore } from 'redux';
+import { batchedSubscribe } from 'redux-batched-subscribe';
+import debounce from 'lodash.debounce';
+
+const batchDebounce = debounce(notify => notify());
+const batchDebounceOnlyRegister = (notify, action) => action.type == 'REGISTER' ? batchDebounce(notify) : notify();
+const finalCreateStore = batchedSubscribe(dontBatchDebounceRegister)(createStore);
+const store = finalCreateStore(reducer, intialState);
+```
+
 ### React batched updates
 
 ```js

--- a/src/__tests__/batchedSubscribe-test.js
+++ b/src/__tests__/batchedSubscribe-test.js
@@ -20,6 +20,18 @@ describe('batchedSubscribe()', () => {
     expect(batchSpy.calls.length).toEqual(1);
   });
 
+  it('it calls batch function with the action as second parameter', () => {
+    const batchSpy = createSpy();
+    const baseStore = createStoreShape();
+    const createStore = () => baseStore;
+    const store = batchedSubscribe(batchSpy)(createStore)();
+
+    const action = { type: 'foo' };
+    store.dispatch(action);
+
+    expect(batchSpy.calls[0].arguments[1]).toEqual(action);
+  });
+
   it('batch callback executes listeners', () => {
     const subscribeCallbackSpy = createSpy();
     const baseStore = createStoreShape();

--- a/src/index.js
+++ b/src/index.js
@@ -14,8 +14,8 @@ export function batchedSubscribe(batch) {
     };
   }
 
-  function notifyListenersBatched() {
-    batch(() => listeners.slice().forEach(listener => listener()));
+  function notifyListenersBatched(...dispatchArgs) {
+    batch(() => listeners.slice().forEach(listener => listener()), ...dispatchArgs);
   }
 
   return next => (...args) => {
@@ -24,7 +24,7 @@ export function batchedSubscribe(batch) {
 
     function dispatch(...dispatchArgs) {
       const res = store.dispatch(...dispatchArgs);
-      notifyListenersBatched();
+      notifyListenersBatched(...dispatchArgs);
       return res;
     }
 


### PR DESCRIPTION
Add the Redux action as a second parameter to the function call by
batchedSubscribe().
