### PR TITLE
Notify only once per batch

### DIFF
--- a/src/__tests__/batchedSubscribe-test.js
+++ b/src/__tests__/batchedSubscribe-test.js
@@ -52,7 +52,7 @@ describe('batchedSubscribe()', () => {
     execute();
     return interactions
       .then(() => expect(subscribeCallbackSpy.calls.length).toEqual(1));
-  })
+  });
 
   it('should execute listeners again on nested dispatch', () => {
     let execute;
@@ -64,7 +64,7 @@ describe('batchedSubscribe()', () => {
       listener1();
       unsubscribe1();
       store.dispatch({ type: 'baz' });
-    })
+    });
     store.subscribe(listener2);
 
     store.dispatch({ type: 'foo' });
@@ -77,8 +77,8 @@ describe('batchedSubscribe()', () => {
       .then(() => {
         expect(listener1.calls.length).toEqual(1);
         expect(listener2.calls.length).toEqual(2);
-      })
-  })
+      });
+  });
 
   it('it exposes base subscribe as subscribeImmediate', () => {
     const store = createBatchedStore();

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ export function batchedSubscribe(batch) {
     throw new Error('Expected batch to be a function.');
   }
 
+  let dispatched = false;
   let currentListeners = [];
   let nextListeners = currentListeners;
 
@@ -36,6 +37,10 @@ export function batchedSubscribe(batch) {
   }
 
   function notifyListeners() {
+    if (!dispatched) {
+      return;
+    }
+    dispatched = false;
     const listeners = currentListeners = nextListeners;
     for (let i = 0; i < listeners.length; i++) {
       listeners[i]();
@@ -52,6 +57,7 @@ export function batchedSubscribe(batch) {
 
     function dispatch(...dispatchArgs) {
       const res = store.dispatch(...dispatchArgs);
+      dispatched = true;
       notifyListenersBatched();
       return res;
     }


### PR DESCRIPTION
Redux subscription is used to notify listeners about changes in redux state. After delaying the notification of a batch of actions, we only need to notify the listeners once about the entire batch of changes because the final state is the only one that matters.
