### PR TITLE
Pass through dispatch action to batch function

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,25 @@ const debounceNotify = debounce(notify => notify());
 const store = createStore(reducer, intialState, batchedSubscribe(debounceNotify));
 ```
 
+### Action based filtering for batch notifications
+
+```js
+import { createStore } from 'redux';
+import { batchedSubscribe } from 'redux-batched-subscribe';
+
+const shouldNotify = (action) => {
+  return !(action && action.meta && action.meta.batch);
+}
+
+const actionBatcher = (notify, action) => {
+  if(shouldNotify(action)) {
+    notify();
+  }
+}
+// Note: passing batchedSubscribe as the last argument to createStore requires redux@>=3.1.0
+const store = createStore(reducer, intialState, batchedSubscribe(actionBatcher));
+```
+
 ### React batched updates
 
 ```js

--- a/src/__tests__/batchedSubscribe-test.js
+++ b/src/__tests__/batchedSubscribe-test.js
@@ -18,13 +18,14 @@ function createBatchedStore(batch = (cb) => cb()) {
 }
 
 describe('batchedSubscribe()', () => {
-  it('it calls batch function on dispatch', () => {
+  it('it calls batch function on dispatch passing through given args.', () => {
     const batchSpy = expect.createSpy();
     const store = createBatchedStore(batchSpy);
 
     store.dispatch({ type: 'foo' });
 
     expect(batchSpy.calls.length).toEqual(1);
+    expect(batchSpy.calls[0].arguments[1]).toEqual({ type: 'foo' });
   });
 
   it('batch callback executes listeners', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -42,8 +42,8 @@ export function batchedSubscribe(batch) {
     }
   }
 
-  function notifyListenersBatched() {
-    batch(notifyListeners);
+  function notifyListenersBatched(...dispatchArgs) {
+    batch(notifyListeners, ...dispatchArgs);
   }
 
   return next => (...args) => {
@@ -52,7 +52,7 @@ export function batchedSubscribe(batch) {
 
     function dispatch(...dispatchArgs) {
       const res = store.dispatch(...dispatchArgs);
-      notifyListenersBatched();
+      notifyListenersBatched(...dispatchArgs);
       return res;
     }
 


### PR DESCRIPTION
Having the action available at the batching function level is important for calculating batch exclusion based on action type. This is important for things like transactional batching triggered by specific actions which is a use case we came across.
