### PR TITLE
Making action & state available to batch function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,8 +42,8 @@ export function batchedSubscribe(batch) {
     }
   }
 
-  function notifyListenersBatched() {
-    batch(notifyListeners);
+  function notifyListenersBatched(action, getState) {
+    batch(notifyListeners, action, getState);
   }
 
   return next => (...args) => {
@@ -52,7 +52,7 @@ export function batchedSubscribe(batch) {
 
     function dispatch(...dispatchArgs) {
       const res = store.dispatch(...dispatchArgs);
-      notifyListenersBatched();
+      notifyListenersBatched(dispatchArgs[0], store.getState);
       return res;
     }
 


### PR DESCRIPTION
See: https://github.com/tappleby/redux-batched-subscribe/issues/16
I'm aware that only forwarding the first dispatch argument, assuming that that's the action, it somewhat opinionated. 