### PR TITLE
add blacklist which tirgger listeners immediately

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export function batchedSubscribe(batch, blacklist) {
+export function batchedSubscribe(batch, blacklist = []) {
   if (typeof batch !== 'function') {
     throw new Error('Expected batch to be a function.');
   }
@@ -54,7 +54,7 @@ export function batchedSubscribe(batch, blacklist) {
       const [action] = dispatchArgs;
       const { type } = action;
       const res = store.dispatch(...dispatchArgs);
-      if (blacklist.include(type)) {
+      if (blacklist.includes(type)) {
         notifyListeners();
       } else {
         notifyListenersBatched();

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ export function batchedSubscribe(batch, blacklist) {
     const subscribeImmediate = store.subscribe;
 
     function dispatch(...dispatchArgs) {
-      const [ action ] = dispatchArgs;
+      const [action] = dispatchArgs;
       const { type } = action;
       const res = store.dispatch(...dispatchArgs);
       if (blacklist.include(type)) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export function batchedSubscribe(batch) {
+export function batchedSubscribe(batch, blacklist) {
   if (typeof batch !== 'function') {
     throw new Error('Expected batch to be a function.');
   }
@@ -51,8 +51,14 @@ export function batchedSubscribe(batch) {
     const subscribeImmediate = store.subscribe;
 
     function dispatch(...dispatchArgs) {
+      const [ action ] = dispatchArgs;
+      const { type } = action;
       const res = store.dispatch(...dispatchArgs);
-      notifyListenersBatched();
+      if (blacklist.include(type)) {
+        notifyListeners();
+      } else {
+        notifyListenersBatched();
+      }
       return res;
     }
 


### PR DESCRIPTION
Sometimes we want some actions, they don't be batched, so add these actions to the `blacklist`, they can trigger the renderer immediately

for  example:
if I have a input is connect to the state, if it is batched, and if I input the value too quickly, it will not show up in the page